### PR TITLE
Remove google-oauth-jwt dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2 (2020-09-23)
+
+* Updated recommended NodeJS version to 10.0.0 or greater.
+* Replaced google-oauth-jwt dependency with a hand-written alternative
+
 ## v1.0.1 (2017-05-04)
 
 * Updated recommended NodeJS version to 6.10.0 or greater.

--- a/auth.js
+++ b/auth.js
@@ -15,7 +15,7 @@ const EXP_SECS = 60 * 60;
 const LIFETIME_SECS = 60 * 55;
 
 const toB64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64');
-const sign = (b, key) => createSign('RSA-SHA256').update(b).sign(key);
+const sign = (b, k) => createSign('RSA-SHA256').update(b).sign(k);
 
 const HEADER = toB64({ alg: 'RS256', typ: 'JWT' });
 

--- a/auth.js
+++ b/auth.js
@@ -45,12 +45,13 @@ const getBearer = async ({ bearerCache, key, email, scopes }) => {
   bearerCache.setFetching();
 
   try {
-    const jwt = getJWT({ key, email, scopes });
-
     const res = await request({
       url: TOKEN_URL,
       method: 'POST',
-      form: { grant_type: GRANT_TYPE, assertion: jwt },
+      form: {
+        grant_type: GRANT_TYPE,
+        assertion: getJWT({ key, email, scopes }),
+      },
     });
 
     bearerCache.setWarm(res.body.access_token, LIFETIME_SECS);

--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,4 @@
 const { createSign } = require('crypto');
-const { readFileSync } = require('fs');
-const qs = require('querystring');
 
 const request = require('./request');
 
@@ -41,7 +39,7 @@ const getBearer = async ({ bearerCache, key, email, scopes }) => {
   }
 
   if (bearerCache.isFetching()) {
-    return bearerCache.await();
+    return bearerCache.wait();
   }
 
   bearerCache.setFetching();

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,66 @@
+const { createSign } = require('crypto');
+const { readFileSync } = require('fs');
+const qs = require('querystring');
+
+const request = require('./request');
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+// When requesting a token, we specify 60 minutes. When setting the local
+// lifetime of a token, we specify 55 minutes. This simple mechanism ought to
+// work us around a race that could occur if we used the same number for both
+// values: our local lifetime check could pass, but still be rejected by
+// Google's API if we're operating right around the expiry epoch.
+//
+const EXP_SECS = 60 * 60;
+const LIFETIME_SECS = 60 * 55;
+
+const toB64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64');
+const sign = (b, key) => createSign('RSA-SHA256').update(b).sign(key);
+
+const HEADER = toB64({ alg: 'RS256', typ: 'JWT' });
+
+const getJWT = ({ key, email, scopes }) => {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: email,
+    scope: scopes.join(' '),
+    aud: TOKEN_URL,
+    exp: now + EXP_SECS,
+    iat: now,
+  };
+
+  const unsigned = `${HEADER}.${toB64(payload)}`;
+  return `${unsigned}.${sign(unsigned, key).toString('base64')}`;
+};
+
+const getBearer = async ({ bearerCache, key, email, scopes }) => {
+  if (bearerCache.isWarm()) {
+    return bearerCache.value();
+  }
+
+  if (bearerCache.isFetching()) {
+    return bearerCache.await();
+  }
+
+  bearerCache.setFetching();
+
+  try {
+    const jwt = getJWT({ key, email, scopes });
+
+    const res = await request({
+      url: TOKEN_URL,
+      method: 'POST',
+      form: { grant_type: GRANT_TYPE, assertion: jwt },
+    });
+
+    bearerCache.setWarm(res.body.access_token, LIFETIME_SECS);
+    return bearerCache.value();
+  } catch (e) {
+    bearerCache.setCold(e);
+    throw e;
+  }
+};
+
+module.exports = { getBearer };

--- a/auth.js
+++ b/auth.js
@@ -55,8 +55,10 @@ const getBearer = async ({ bearerCache, key, email, scopes }) => {
       },
     });
 
-    // Ensure our lifetime never goes below the value reported by the API. We
-    // expect to always be able to apply 5 minutes of padding.
+    // Ensure our lifetime, with padding, never goes below 0. If it does, fall
+    // back to the lifetime reported by the server. We'll likely start seeing a
+    // small number of auth failures. We always expect to be able to apply
+    // padding.
     let lifetime = res.body.expires_in - EXP_PADDING_SECS;
     if (lifetime <= 0) {
       lifetime = res.body.expires_in;

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -1,0 +1,78 @@
+const STATES = {
+  FETCHING: 'FETCHING',
+  WARM: 'WARM',
+  COLD: 'COLD',
+};
+
+class BearerCache {
+  constructor() {
+    this.token = null;
+    this.expiresAt = null;
+    this.fetcher = null;
+    this.resolver = null;
+    this.rejecter = null;
+  }
+
+  value() {
+    return this.token;
+  }
+
+  state() {
+    if (this.fetcher !== null) {
+      return STATES.FETCHING;
+    }
+
+    if (this.token && this.expiresAt > Date.now()) {
+      return STATES.WARM;
+    }
+
+    return STATES.COLD;
+  }
+
+  isWarm() {
+    return this.state() === STATES.WARM;
+  }
+
+  isCold() {
+    return this.state() === STATES.COLD;
+  }
+
+  isFetching() {
+    return this.state() === STATES.FETCHING;
+  }
+
+  setWarm(token, lifetimeSecs) {
+    this.token = token;
+    this.expiresAt = Date.now() + (lifetimeSecs * 1000);
+
+    this.resolver(token);
+
+    this.fetcher = null;
+    this.resolver = null;
+    this.rejecter = null;
+  }
+
+  setCold(reason) {
+    this.token = null;
+    this.expiresAt = null;
+
+    this.rejecter(reason);
+
+    this.fetcher = null;
+    this.resolver = null;
+    this.rejecter = null;
+  }
+
+  setFetching() {
+    this.fetcher = new Promise((resolve, reject) => {
+      this.resolver = resolve;
+      this.rejecter = reject;
+    });
+  }
+
+  await() {
+    return this.fetcher;
+  }
+}
+
+module.exports = BearerCache;

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -1,9 +1,41 @@
+const assert = require('assert');
+
 const STATES = {
+  COLD: 'COLD',
   FETCHING: 'FETCHING',
   WARM: 'WARM',
-  COLD: 'COLD',
 };
 
+/**
+ * The BearerCache implements a simple state machine for managing the lifecycle
+ * of an authentication token.
+ *
+ * When instantiated, a cache will be in the Cold state: it has no token. The
+ * Cold state can transition to the Fetching state, indicating that a request
+ * has been initiated for a token.
+ *
+ * In the Fetching state, callers can queue up for the result by awaiting the
+ * promise returned by #wait. If the fetch fails, the cache can transition to
+ * the Cold state -- anyone awaiting the result will receive a rejection with
+ * the reason. If the fetch succeeds, the cache can transition to the Warm state
+ * -- anyone awaiting the result will receive a resolution with the token.
+ *
+ * In the Warm state, callers can simply query for the token with #value. When
+ * a token is deemed expired, based on a finite lifetime, the cache
+ * automatically transitions back to Cold.
+ *
+ *            ┌───────────┐         ┌───────────┐
+ *            │           ├──Fetch──▶           │
+ * ───Create──▶   Cold    │         │ Fetching  │
+ *            │           ◀──Fail───┤           │
+ *            └─────▲─────┘         └─────┬─────┘
+ *                  │                     │
+ *               Expire  ┌───────────┐ Succeed
+ *                  │    │           │    │
+ *                  └────│   Warm    ◀────┘
+ *                       │           │
+ *                       └───────────┘
+ */
 class BearerCache {
   constructor() {
     this.token = null;
@@ -11,10 +43,6 @@ class BearerCache {
     this.fetcher = null;
     this.resolver = null;
     this.rejecter = null;
-  }
-
-  value() {
-    return this.token;
   }
 
   state() {
@@ -42,6 +70,8 @@ class BearerCache {
   }
 
   setWarm(token, lifetimeSecs) {
+    assert(this.isFetching());
+
     this.token = token;
     this.expiresAt = Date.now() + (lifetimeSecs * 1000);
 
@@ -53,6 +83,8 @@ class BearerCache {
   }
 
   setCold(reason) {
+    assert(this.isFetching() || this.isWarm());
+
     this.token = null;
     this.expiresAt = null;
 
@@ -64,13 +96,21 @@ class BearerCache {
   }
 
   setFetching() {
+    assert(this.isCold());
+
     this.fetcher = new Promise((resolve, reject) => {
       this.resolver = resolve;
       this.rejecter = reject;
     });
   }
 
+  value() {
+    assert(this.isWarm());
+    return this.token;
+  }
+
   wait() {
+    assert(this.isFetching());
     return this.fetcher;
   }
 }

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -70,7 +70,7 @@ class BearerCache {
   }
 
   setWarm(token, lifetimeSecs) {
-    assert(this.isFetching());
+    assert(this.isFetching(), 'Cache must be fetching to set to warm');
 
     this.token = token;
     this.expiresAt = Date.now() + (lifetimeSecs * 1000);
@@ -83,7 +83,7 @@ class BearerCache {
   }
 
   setCold(reason) {
-    assert(this.isFetching() || this.isWarm());
+    assert(this.isFetching(), 'Cache must be fetching to set to cold');
 
     this.token = null;
     this.expiresAt = null;
@@ -96,7 +96,7 @@ class BearerCache {
   }
 
   setFetching() {
-    assert(this.isCold());
+    assert(this.isCold(), 'Cache must be cold to set to fetching');
 
     this.fetcher = new Promise((resolve, reject) => {
       this.resolver = resolve;
@@ -105,12 +105,12 @@ class BearerCache {
   }
 
   value() {
-    assert(this.isWarm());
+    assert(this.isWarm(), 'Cache must be warm to return a value');
     return this.token;
   }
 
   wait() {
-    assert(this.isFetching());
+    assert(this.isFetching(), 'Cache must be fetching to wait on a value');
     return this.fetcher;
   }
 }

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -71,7 +71,7 @@ class BearerCache {
 
   setWarm(token, lifetimeSecs) {
     assert(token, 'Must specify a token to set to warm');
-    assert(lifetimeSecs, 'Must specify non-zero lifetime of the token');
+    assert(lifetimeSecs > 0, 'Must specify non-zero lifetime of the token');
     assert(this.isFetching(), 'Cache must be fetching to set to warm');
 
     this.token = token;

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -70,7 +70,7 @@ class BearerCache {
     });
   }
 
-  await() {
+  wait() {
     return this.fetcher;
   }
 }

--- a/bearer-cache.js
+++ b/bearer-cache.js
@@ -70,6 +70,8 @@ class BearerCache {
   }
 
   setWarm(token, lifetimeSecs) {
+    assert(token, 'Must specify a token to set to warm');
+    assert(lifetimeSecs, 'Must specify non-zero lifetime of the token');
     assert(this.isFetching(), 'Cache must be fetching to set to warm');
 
     this.token = token;
@@ -83,6 +85,7 @@ class BearerCache {
   }
 
   setCold(reason) {
+    assert(reason, 'Must specify a reason to set to cold');
     assert(this.isFetching(), 'Cache must be fetching to set to cold');
 
     this.token = null;

--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,30 @@
+/** Base error class. */
+class MinQueryError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    this.message = message;
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = new Error(message).stack;
+    }
+  }
+}
+
+/** Any sort of response error. */
+class ResponseError extends MinQueryError {
+  constructor(message, response) {
+    super(message);
+    this.response = response;
+  }
+}
+
+/** Bigquery API returned an error. */
+class ProtocolError extends ResponseError {}
+
+module.exports = {
+  MinQueryError,
+  ResponseError,
+  ProtocolError,
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-mocha": "^4.9.0",
     "mocha": "^3.1.0",
     "mocha-eslint": "^3.0.1",
-    "nock": "^8.1.0"
+    "nock": "^8.1.0",
+    "sinon": "^9.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Button <info@usebutton.com>",
   "license": "MIT",
   "dependencies": {
-    "google-oauth-jwt": "^0.2.0"
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/minquery",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Minimal client for Google Bigquery",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "test": "mocha --recursive tests/"
   },
   "engines": {
-    "node": ">=6.10.0"
+    "node": ">=10.0.0"
   },
   "author": "Button <info@usebutton.com>",
   "license": "MIT",

--- a/request.js
+++ b/request.js
@@ -17,11 +17,15 @@ const request = async (options) =>
         return;
       }
 
-      // Instead of using the `json` property in the request options, which
-      // impacts both request and response behavior, simply parse the response
-      // if it's declared to be JSON.
+      const contentType = res.headers['content-type'];
+
+      // If options.json=true, then request.js will automatically parse response
+      // bodies as JSON. Some calls may not be able to pass options.json=true
+      // (for example, if the request body is not JSON), but may still receive
+      // a JSON response. Accordingly, this condition attempts to parse a JSON
+      // response, but only if it wasn't already parsed by request.js.
       if (
-        res.headers['content-type'].startsWith('application/json') &&
+        contentType && contentType.startsWith('application/json') &&
         !options.json
       ) {
         res.body = JSON.parse(res.body);

--- a/request.js
+++ b/request.js
@@ -25,10 +25,16 @@ const request = async (options) =>
       // a JSON response. Accordingly, this condition attempts to parse a JSON
       // response, but only if it wasn't already parsed by request.js.
       if (
-        contentType && contentType.startsWith('application/json') &&
+        contentType &&
+        contentType.startsWith('application/json') &&
         !options.json
       ) {
-        res.body = JSON.parse(res.body);
+        try {
+          res.body = JSON.parse(res.body);
+        } catch (e) {
+          reject(new ProtocolError(e.message), res);
+          return;
+        }
       }
 
       if (res.body.error) {

--- a/request.js
+++ b/request.js
@@ -2,6 +2,13 @@ const _request = require('request');
 
 const { ProtocolError } = require('./errors');
 
+/**
+ * Light wrapper around request.js. Returns a Promise and handles a couple
+ * Google-specific protocol interpretations.
+ *
+ * @param  {Object} options Forwarded to request.js
+ * @return {Promise} resolves with the request.js response
+ */
 const request = async (options) =>
   new Promise((resolve, reject) => {
     _request(options, (err, res) => {
@@ -9,9 +16,12 @@ const request = async (options) =>
         reject(err);
       }
 
+      // Instead of using the `json` property in the request options, which
+      // impacts both request and response behavior, simply parse the response
+      // if it's declared to be JSON.
       if (
         res.headers['content-type'].startsWith('application/json;') &&
-        typeof res.body === 'string'
+        !options.json
       ) {
         res.body = JSON.parse(res.body);
       }

--- a/request.js
+++ b/request.js
@@ -14,13 +14,14 @@ const request = async (options) =>
     _request(options, (err, res) => {
       if (err) {
         reject(err);
+        return;
       }
 
       // Instead of using the `json` property in the request options, which
       // impacts both request and response behavior, simply parse the response
       // if it's declared to be JSON.
       if (
-        res.headers['content-type'].startsWith('application/json;') &&
+        res.headers['content-type'].startsWith('application/json') &&
         !options.json
       ) {
         res.body = JSON.parse(res.body);
@@ -30,6 +31,7 @@ const request = async (options) =>
         reject(
           new ProtocolError(res.body.error.message || 'API response error', res)
         );
+        return;
       }
 
       resolve(res);

--- a/request.js
+++ b/request.js
@@ -16,7 +16,7 @@ const request = async (options) =>
         res.body = JSON.parse(res.body);
       }
 
-      if (res && res.body.error) {
+      if (res.body.error) {
         reject(
           new ProtocolError(res.body.error.message || 'API response error', res)
         );

--- a/request.js
+++ b/request.js
@@ -32,7 +32,7 @@ const request = async (options) =>
         try {
           res.body = JSON.parse(res.body);
         } catch (e) {
-          reject(new ProtocolError(e.message), res);
+          reject(new ProtocolError(e.message, res));
           return;
         }
       }

--- a/request.js
+++ b/request.js
@@ -1,0 +1,29 @@
+const _request = require('request');
+
+const { ProtocolError } = require('./errors');
+
+const request = async (options) =>
+  new Promise((resolve, reject) => {
+    _request(options, (err, res) => {
+      if (err) {
+        reject(err);
+      }
+
+      if (
+        res.headers['content-type'].startsWith('application/json;') &&
+        typeof res.body === 'string'
+      ) {
+        res.body = JSON.parse(res.body);
+      }
+
+      if (res && res.body.error) {
+        reject(
+          new ProtocolError(res.body.error.message || 'API response error', res)
+        );
+      }
+
+      resolve(res);
+    });
+  });
+
+module.exports = request;

--- a/tests/auth-test.js
+++ b/tests/auth-test.js
@@ -1,0 +1,124 @@
+/* eslint-disable max-len, no-await-in-loop */
+
+const { readFileSync } = require('fs');
+const nock = require('nock');
+const sinon = require('sinon');
+const assert = require('assert');
+
+const { getBearer } = require('../auth');
+const BearerCache = require('../bearer-cache');
+
+const key = readFileSync(`${__dirname}/fixtures/fake-key.pem`);
+
+describe('auth', function () {
+  beforeEach(function () {
+    this.sandbox = sinon.createSandbox();
+    this.clock = this.sandbox.useFakeTimers(0);
+
+    nock.disableNetConnect();
+    nock.enableNetConnect('127.0.0.1');
+  });
+
+  afterEach(function () {
+    this.sandbox.restore();
+
+    nock.enableNetConnect();
+    nock.cleanAll();
+  });
+
+  describe('#getBearer', function () {
+    beforeEach(function () {
+      this.cache = new BearerCache();
+      this.arguments = {
+        bearerCache: this.cache,
+        key,
+        email: 'daniel@hoho.com',
+        scopes: ['bloop', 'bleep'],
+      };
+    });
+
+    it('returns a cached token', async function () {
+      this.cache.setFetching();
+      this.cache.setWarm('token', 1);
+
+      const res = await getBearer(this.arguments);
+
+      assert.deepStrictEqual(res, 'token');
+    });
+
+    it('requests a new token when cold and allows other calls to wait', async function () {
+      const scope = nock('https://oauth2.googleapis.com')
+        .post('/token', {
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion:
+            'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkYW5pZWxAaG9oby5jb20iLCJzY29wZSI6ImJsb29wIGJsZWVwIiwiYXVkIjoiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLCJleHAiOjM2MDAsImlhdCI6MH0=.inXy76Q7+cBzbygepCDcPDE254HmU1iOhxhi/hRWm5rkVW8EckMek5qkC90eUY08QZLL1d3UXiZf75iJXC8jtIMLNX+NZmp9fTPFvRkWtxhhvwGLxBzZr42yv06rHKH3+WizGiooz/u9aOpplnVFreZsXrxJyo/6WfD6+lnr3yBDcK0h2C0UUNfA7/8ELJ43pM+tHrGHk0z15M0d8MUpm1vUTh7s4cjCM8cYc/s8KndMIaJftjA+kZzYmQCv5C7/YRSQByHYNa25wIpi50wssnuxxej6GBOXShAURXxgdrZIqNpIIi+E3zTU12vVheq5UoysZyp7J5g1e+Ych06U7g==',
+        })
+        .reply(200, { access_token: 'token' });
+
+      const p1 = getBearer(this.arguments);
+      const p2 = getBearer(this.arguments);
+      const p3 = getBearer(this.arguments);
+
+      assert.deepStrictEqual(await Promise.all([p1, p2, p3]), [
+        'token',
+        'token',
+        'token',
+      ]);
+
+      scope.done();
+
+      // Now that the cache is warm, we can get the value without extra network
+      // hops
+      assert.deepStrictEqual(await getBearer(this.arguments), 'token');
+
+      // Now let the token expire
+      this.clock.tick(60 * 55 * 1000);
+
+      const refreshScope = nock('https://oauth2.googleapis.com')
+        .post('/token', {
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion:
+            'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkYW5pZWxAaG9oby5jb20iLCJzY29wZSI6ImJsb29wIGJsZWVwIiwiYXVkIjoiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLCJleHAiOjY5MDAsImlhdCI6MzMwMH0=.RQWl/KelPs6bxk+r5gWFMXz8zwf6q8XoHsffkRAquonLbjIx2oZOqjtizHo0yY2/w1HuanRfR1rgfl6qMiRyxtoiMPt69e3oPrjqpuTxK0sg9MtGPvPGMS0SdvEVKAPOUrpnIuDhx7NvVIzNKV3YNRYUKynCQisDPHJvsno3pW3HRWT9K1PNh1ZtRVp1KLWWqSppK+TUh/cbzgljDT0KCCuxxvC8x2vv7HVjZOX2W7XJPdiDqWAUKgk1rez8iM7oupKu7ZK6T2iR/OFb6BfM10u/AXv0OoOOwhWcP5nr+UvTXmfZsbBb8mrQXyTGJMa/YUdbSi3R9x3MneaGlVMGRA==',
+        })
+        .reply(200, { access_token: 'refresh' });
+
+      const p4 = getBearer(this.arguments);
+      const p5 = getBearer(this.arguments);
+
+      assert.deepStrictEqual(await Promise.all([p4, p5]), [
+        'refresh',
+        'refresh',
+      ]);
+
+      refreshScope.done();
+    });
+
+    it('rejects all callers when requesting a token fails', async function () {
+      const scope = nock('https://oauth2.googleapis.com')
+        .post('/token')
+        .reply(500, { error: { message: 'blooped the big one' } });
+
+      const p1 = getBearer(this.arguments);
+      const p2 = getBearer(this.arguments);
+      const p3 = getBearer(this.arguments);
+
+      for (const p of [p1, p2, p3]) {
+        await assert.rejects(() => p, {
+          name: 'ProtocolError',
+          message: 'blooped the big one',
+        });
+      }
+
+      scope.done();
+
+      // Now try to get back on the rails with a successful fetch
+      const retryScope = nock('https://oauth2.googleapis.com')
+        .post('/token')
+        .reply(200, { access_token: 'retry' });
+
+      assert.deepStrictEqual(await getBearer(this.arguments), 'retry');
+
+      retryScope.done();
+    });
+  });
+});

--- a/tests/bearer-cache-test.js
+++ b/tests/bearer-cache-test.js
@@ -3,14 +3,14 @@ const assert = require('assert');
 
 const BearerCache = require('../bearer-cache');
 
-describe.only('bearer-cache', function () {
-  beforeEach(function() {
+describe('bearer-cache', function () {
+  beforeEach(function () {
     this.sandbox = sinon.createSandbox();
-  })
+  });
 
-  afterEach(function() {
+  afterEach(function () {
     this.sandbox.restore();
-  })
+  });
 
   describe('cold', function () {
     beforeEach(function () {

--- a/tests/bearer-cache-test.js
+++ b/tests/bearer-cache-test.js
@@ -1,0 +1,163 @@
+const assert = require('assert');
+
+const BearerCache = require('../bearer-cache');
+
+describe('bearer-cache', function () {
+  describe('cold', function () {
+    beforeEach(function () {
+      this.cache = new BearerCache();
+    });
+
+    it('is in the cold state on construction', function () {
+      assert(this.cache.isCold());
+    });
+
+    it('cannot return a value', function () {
+      assert.throws(() => this.cache.value(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be warm to return a value',
+      });
+    });
+
+    it('cannot be waited on', function () {
+      assert.throws(() => this.cache.wait(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be fetching to wait on a value',
+      });
+    });
+
+    it('can transition to fetching', function () {
+      this.cache.setFetching();
+      assert(this.cache.isFetching());
+    });
+
+    it('cannot transition to warm', function () {
+      assert.throws(() => this.cache.setWarm(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be fetching to set to warm',
+      });
+    });
+
+    it('cannot transition to cold', function () {
+      assert.throws(() => this.cache.setCold(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be fetching to set to cold',
+      });
+    });
+  });
+
+  describe('fetching', function () {
+    beforeEach(function () {
+      this.cache = new BearerCache();
+      this.cache.setFetching();
+    });
+
+    it('is in the fetching state', function () {
+      assert(this.cache.isFetching());
+    });
+
+    it('cannot return a value', function () {
+      assert.throws(() => this.cache.value(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be warm to return a value',
+      });
+    });
+
+    it('can be waited on', async function () {
+      setImmediate(() => this.cache.setWarm('bloop', 1));
+      assert(this.cache.isFetching());
+
+      const res = await this.cache.wait();
+
+      assert(this.cache.isWarm());
+      assert.deepStrictEqual(res, 'bloop');
+    });
+
+    it('can be waited on and reject', async function () {
+      setImmediate(() => this.cache.setCold(new Error('blooped the big one')));
+      assert(this.cache.isFetching());
+
+      await assert.rejects(() => this.cache.wait(), {
+        name: 'Error',
+        message: 'blooped the big one',
+      });
+
+      assert(this.cache.isCold());
+    });
+
+    it('can be waited on by multiple receivers', async function () {
+      setImmediate(() => this.cache.setWarm('bloop', 1));
+      assert(this.cache.isFetching());
+
+      const res = await Promise.all([this.cache.wait(), this.cache.wait()]);
+
+      assert(this.cache.isWarm());
+      assert.deepStrictEqual(res, ['bloop', 'bloop']);
+    });
+
+    it('cannot transition to fetching', function () {
+      assert.throws(() => this.cache.setFetching(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be cold to set to fetching',
+      });
+    });
+
+    it('can transition to warm', function () {
+      this.cache.setWarm('bloop', 1);
+      assert(this.cache.isWarm());
+    });
+
+    it('can transition to cold', async function () {
+      setImmediate(() => this.cache.setCold(new Error('bloop')));
+
+      await assert.rejects(() => this.cache.wait());
+
+      assert(this.cache.isCold());
+    });
+  });
+
+  describe('warm', function () {
+    beforeEach(function () {
+      this.cache = new BearerCache();
+      this.cache.setFetching();
+      this.cache.setWarm('bloop', 1);
+    });
+
+    it('is in the warm state', function () {
+      assert(this.cache.isWarm());
+    });
+
+    it('can return a value', function () {
+      assert.deepStrictEqual(this.cache.value(), 'bloop');
+    });
+
+    it('cannot be waited on', function () {
+      assert.throws(() => this.cache.wait(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be fetching to wait on a value',
+      });
+    });
+
+    it('cannot transition to fetching', function () {
+      assert.throws(() => this.cache.setFetching(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be cold to set to fetching',
+      });
+    });
+
+    it('cannot transition to warm', function () {
+      assert.throws(() => this.cache.setWarm(), {
+        name: 'AssertionError [ERR_ASSERTION]',
+        message: 'Cache must be fetching to set to warm',
+      });
+    });
+
+    it('can transition to cold', async function () {
+      assert(this.cache.isWarm());
+
+      await new Promise(r => setTimeout(r, 1000));
+
+      assert(this.cache.isCold());
+    });
+  });
+});

--- a/tests/fixtures/create-table-good.json
+++ b/tests/fixtures/create-table-good.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/fixtures/insert-good.json
+++ b/tests/fixtures/insert-good.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/fixtures/insert-invalid-row-ignored.json
+++ b/tests/fixtures/insert-invalid-row-ignored.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/fixtures/insert-invalid-row-rejected.json
+++ b/tests/fixtures/insert-invalid-row-rejected.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/fixtures/insert-invalid-value-ignored.json
+++ b/tests/fixtures/insert-invalid-value-ignored.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/fixtures/insert-invalid-value-rejected.json
+++ b/tests/fixtures/insert-invalid-value-rejected.json
@@ -1,15 +1,16 @@
 [
     {
-        "scope": "https://accounts.google.com:443",
+        "scope": "https://oauth2.googleapis.com",
         "method": "POST",
-        "path": "/o/oauth2/token",
+        "path": "/token",
         "body": "*",
         "status": 200,
         "response": {
             "access_token": "fake",
             "token_type": "Bearer",
             "expires_in": 3600
-        }
+        },
+        "rawHeaders": ["Content-Type", "application/json; charset=UTF-8"]
     },
     {
         "scope": "https://www.googleapis.com:443",

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -76,10 +76,7 @@ describe('request', function () {
   it('rejects with protocol-level errors', async function () {
     const scope = nock('https://localhost')
       .post('/bloop')
-      .reply(
-        500,
-        { error: { message: 'blooped the big one' } }
-      );
+      .reply(500, { error: { message: 'blooped the big one' } });
 
     await assert.rejects(
       () => request({ url: 'https://localhost/bloop', method: 'post' }),
@@ -95,11 +92,7 @@ describe('request', function () {
   it('rejects with invalid JSON responses', async function () {
     const scope = nock('https://localhost')
       .post('/bloop')
-      .reply(
-        200,
-        '{ "bad": json }',
-        { 'Content-Type': 'application/json' }
-      );
+      .reply(200, '{ "bad": json }', { 'Content-Type': 'application/json' });
 
     await assert.rejects(
       () => request({ url: 'https://localhost/bloop', method: 'post' }),

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -15,12 +15,12 @@ describe('request', function () {
   });
 
   it('makes a network request and returns a promise', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
 
     const res = await request({
-      url: 'https://site.com/bloop',
+      url: 'https://localhost/bloop',
       method: 'post',
     });
 
@@ -29,12 +29,12 @@ describe('request', function () {
   });
 
   it('doesnt parse a JSON response body if handled by request.js', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
 
     const res = await request({
-      url: 'https://site.com/bloop',
+      url: 'https://localhost/bloop',
       method: 'post',
       json: true,
     });
@@ -44,12 +44,12 @@ describe('request', function () {
   });
 
   it('rejects with networking-level errors', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .replyWithError('blooped the big one');
 
     await assert.rejects(
-      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      () => request({ url: 'https://localhost/bloop', method: 'post' }),
       {
         name: 'Error',
         message: 'blooped the big one',
@@ -60,12 +60,12 @@ describe('request', function () {
   });
 
   it('resolves with http-level errors', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .reply(500, { status: 'error' }, { 'Content-Type': 'application/json' });
 
     const res = await request({
-      url: 'https://site.com/bloop',
+      url: 'https://localhost/bloop',
       method: 'post',
     });
 
@@ -74,7 +74,7 @@ describe('request', function () {
   });
 
   it('rejects with protocol-level errors', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .reply(
         500,
@@ -83,7 +83,7 @@ describe('request', function () {
       );
 
     await assert.rejects(
-      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      () => request({ url: 'https://localhost/bloop', method: 'post' }),
       {
         name: 'ProtocolError',
         message: 'blooped the big one',
@@ -94,7 +94,7 @@ describe('request', function () {
   });
 
   it('rejects with invalid JSON responses', async function () {
-    const scope = nock('https://site.com')
+    const scope = nock('https://localhost')
       .post('/bloop')
       .reply(
         200,
@@ -103,7 +103,7 @@ describe('request', function () {
       );
 
     await assert.rejects(
-      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      () => request({ url: 'https://localhost/bloop', method: 'post' }),
       {
         name: 'ProtocolError',
         message: 'Unexpected token j in JSON at position 9',

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -92,4 +92,24 @@ describe('request', function () {
 
     scope.done();
   });
+
+  it('rejects with invalid JSON responses', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .reply(
+        200,
+        '{ "bad": json }',
+        { 'Content-Type': 'application/json' }
+      );
+
+    await assert.rejects(
+      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      {
+        name: 'ProtocolError',
+        message: 'Unexpected token j in JSON at position 9',
+      }
+    );
+
+    scope.done();
+  });
 });

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -1,0 +1,95 @@
+const assert = require('assert');
+const nock = require('nock');
+
+const request = require('../request');
+
+describe('request', function () {
+  beforeEach(function () {
+    nock.disableNetConnect();
+    nock.enableNetConnect('127.0.0.1');
+  });
+
+  afterEach(function () {
+    nock.enableNetConnect();
+    nock.cleanAll();
+  });
+
+  it('makes a network request and returns a promise', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
+
+    const res = await request({
+      url: 'https://site.com/bloop',
+      method: 'post',
+    });
+
+    assert.deepStrictEqual(res.body, { status: 'ok' });
+    scope.done();
+  });
+
+  it('doesnt parse a JSON response body if handled by request.js', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
+
+    const res = await request({
+      url: 'https://site.com/bloop',
+      method: 'post',
+      json: true,
+    });
+
+    assert.deepStrictEqual(res.body, { status: 'ok' });
+    scope.done();
+  });
+
+  it('rejects with networking-level errors', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .replyWithError('blooped the big one');
+
+    await assert.rejects(
+      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      {
+        name: 'Error',
+        message: 'blooped the big one',
+      }
+    );
+
+    scope.done();
+  });
+
+  it('resolves with http-level errors', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .reply(500, { status: 'error' }, { 'Content-Type': 'application/json' });
+
+    const res = await request({
+      url: 'https://site.com/bloop',
+      method: 'post',
+    });
+
+    assert.deepStrictEqual(res.body, { status: 'error' });
+    scope.done();
+  });
+
+  it('rejects with protocol-level errors', async function () {
+    const scope = nock('https://site.com')
+      .post('/bloop')
+      .reply(
+        500,
+        { error: { message: 'blooped the big one' } },
+        { 'Content-Type': 'application/json' }
+      );
+
+    await assert.rejects(
+      () => request({ url: 'https://site.com/bloop', method: 'post' }),
+      {
+        name: 'ProtocolError',
+        message: 'blooped the big one',
+      }
+    );
+
+    scope.done();
+  });
+});

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -17,7 +17,7 @@ describe('request', function () {
   it('makes a network request and returns a promise', async function () {
     const scope = nock('https://localhost')
       .post('/bloop')
-      .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
+      .reply(200, { status: 'ok' });
 
     const res = await request({
       url: 'https://localhost/bloop',
@@ -31,7 +31,7 @@ describe('request', function () {
   it('doesnt parse a JSON response body if handled by request.js', async function () {
     const scope = nock('https://localhost')
       .post('/bloop')
-      .reply(200, { status: 'ok' }, { 'Content-Type': 'application/json' });
+      .reply(200, { status: 'ok' });
 
     const res = await request({
       url: 'https://localhost/bloop',
@@ -62,7 +62,7 @@ describe('request', function () {
   it('resolves with http-level errors', async function () {
     const scope = nock('https://localhost')
       .post('/bloop')
-      .reply(500, { status: 'error' }, { 'Content-Type': 'application/json' });
+      .reply(500, { status: 'error' });
 
     const res = await request({
       url: 'https://localhost/bloop',
@@ -78,8 +78,7 @@ describe('request', function () {
       .post('/bloop')
       .reply(
         500,
-        { error: { message: 'blooped the big one' } },
-        { 'Content-Type': 'application/json' }
+        { error: { message: 'blooped the big one' } }
       );
 
     await assert.rejects(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,42 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.1.0.tgz#3afe719232b541bb6cf3411a4c399a188de21ec0"
+  integrity sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -268,6 +304,11 @@ delayed-stream@~1.0.0:
 diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^2.0.0:
   version "2.0.0"
@@ -595,6 +636,11 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -694,6 +740,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -763,6 +814,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -800,6 +856,11 @@ lodash.create@3.1.1:
     lodash._baseassign "^3.0.0"
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -908,6 +969,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 nock@^8.1.0:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/nock/-/nock-8.2.1.tgz#64cc65e1bdd3893f58cba7e1abfdc38f40f0364a"
@@ -970,6 +1042,13 @@ path-is-inside@^1.0.1:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -1146,6 +1225,19 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+sinon@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.3.tgz#bffc3ec28c936332cd2a41833547b9eed201ecff"
+  integrity sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
+  dependencies:
+    "@sinonjs/commons" "^1.7.2"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.1.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -1214,6 +1306,13 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -1264,6 +1363,11 @@ type-check@~0.3.2:
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-detect@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,12 +20,22 @@ ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv@^4.7.0, ajv@^4.9.1:
+ajv@^4.7.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^6.12.3:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -67,10 +77,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
@@ -79,13 +85,15 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.2.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+aws4@^1.8.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
+  integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
 babel-code-frame@^6.16.0:
   version "6.22.0"
@@ -104,12 +112,6 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
 
 brace-expansion@^1.0.0:
   version "1.1.7"
@@ -180,9 +182,10 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -208,12 +211,6 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  dependencies:
-    boom "2.x.x"
-
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -232,7 +229,7 @@ debug@2.6.0:
   dependencies:
     ms "0.7.2"
 
-debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
+debug@^2.1.1, debug@^2.2.0:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
   dependencies:
@@ -451,13 +448,24 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
-extend@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -490,12 +498,13 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
@@ -551,13 +560,6 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-oauth-jwt@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/google-oauth-jwt/-/google-oauth-jwt-0.2.0.tgz#48f5762d0cc1163cf26a307648c82174b6ae94e7"
-  dependencies:
-    debug "^2.1.3"
-    request ">=2.55"
-
 graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -570,16 +572,18 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -591,24 +595,12 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
+    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -731,6 +723,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -828,15 +825,27 @@ lodash@~4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.9.0.tgz#4c20d742f03ce85dc700e0dd7ab9bcab85e6fc14"
 
+mime-db@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
 mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-types@^2.1.12:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mime-types@~2.1.19:
+  version "2.1.27"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  dependencies:
+    mime-db "1.44.0"
 
 minimatch@^3.0.2:
   version "3.0.3"
@@ -916,9 +925,10 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-oauth-sign@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
@@ -961,9 +971,10 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pify@^2.0.0:
   version "2.3.0"
@@ -999,13 +1010,24 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+psl@^1.1.28:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
-qs@^6.0.2, qs@~6.4.0:
+punycode@^2.1.0, punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.0.2:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 ramda@^0.23.0:
   version "0.23.0"
@@ -1041,32 +1063,31 @@ replaceall@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/replaceall/-/replaceall-0.1.6.tgz#81d81ac7aeb72d7f5c4942adf2697a3220688d8e"
 
-request@>=2.55:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
   dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
     caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
+    uuid "^3.3.2"
 
 require-uncached@^1.0.2:
   version "1.0.3"
@@ -1112,6 +1133,11 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+safe-buffer@^5.1.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 shelljs@^0.7.5:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
@@ -1123,12 +1149,6 @@ shelljs@^0.7.5:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1169,10 +1189,6 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
   dependencies:
     buffer-shims "~1.0.0"
-
-stringstream@~0.0.4:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -1217,11 +1233,13 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
-    punycode "^1.4.1"
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -1255,6 +1273,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+uri-js@^4.2.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz#aa714261de793e8a82347a7bcc9ce74e86f28602"
+  integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
+  dependencies:
+    punycode "^2.1.0"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -1265,9 +1290,10 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
### Background

I've observed this library infrequently, but consistently raising the following error: 

```
ProtocolError: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.
```

I was able to replicate this bug locally by requesting a token from Google, waiting for it to expire, and then attempting to use it with an operation against BigQuery. Between that and the cadence I'm observing errors at (_about_ once an hour), I believe what we're observing is a race between when `google-oauth-jwt` considers a token expired and Google's API. 

The consequence of this is every now and again we drop BigQuery inserts.

### Going a bit deeper...

The BigQuery API requires that you periodically fetch a token to authenticate API calls. These tokens have a finite lifetime, typically 1 hour (in fact, when I tried to request that Google return me a token with a shorter or longer lifetime, it still returned to me one with an hour expiration -- unsure if that's a feature or bug).

Here we use `google-oauth-jwt` to manage the fetching and caching of these tokens. The library supports an "expiration" option, which lets a caller configure the desired lifetime of a token. Unfortunately, the library uses that same expiration option in two places:

1) When instructing Google's server how long a token should live.
2) When setting the local moment that a token should be considered expired, and we should re-fetch.

I believe this is problematic because, with non-zero network latencies and clock skew, `google-oauth-jwt` could consider a token unexpired, only to have it rejected milliseconds later when the BigQuery API tries to authenticate with it, and finds it now expired. Of course, this would only occur _right around_ the moment a token expires... and unfortunately our cache doesn't feature any sort of timing padding to make this unlikely.

### Proposed Fix

First, a couple options I steered away from:

1) We could upstream a fix to `google-oauth-jwt`. I didn't go this route because the last commit occurred 5 years ago, and there were a handful of other anachronisms in there I didn't want to work against (legacy hostnames, etc).
2) We could try exploiting the fact that Google's API doesn't seem to respect the expiration argument. If we set the expiration to 55 minutes and Google still used an expiration of 60 minutes, we'd basically get the timing padding we're after to make this error unlikely. I didn't go this route because I didn't want to rely on pathological behavior. 

Instead I chose to rewrite the aspects of `google-oauth-jwt` we needed:  fetching and caching tokens. This seems aligned with this library's goal of a minimal-dep/lightweight alternative.

I'll call out other specifics inline; hopefully the design more or less speaks for itself.