### PR TITLE
Fixup TypeError with empty response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.3 (2021-09-28)
+
+* Fixup TypeError with empty response bodies.
+
 ## v1.0.2 (2020-09-23)
 
 * Updated recommended NodeJS version to 10.0.0 or greater.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/minquery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Minimal client for Google Bigquery",
   "repository": {
     "type": "git",

--- a/request.js
+++ b/request.js
@@ -37,7 +37,7 @@ const request = async (options) =>
         }
       }
 
-      if (res.body.error) {
+      if (res.body && res.body.error) {
         reject(
           new ProtocolError(res.body.error.message || 'API response error', res)
         );

--- a/tests/request-test.js
+++ b/tests/request-test.js
@@ -104,4 +104,22 @@ describe('request', function () {
 
     scope.done();
   });
+
+  it('gracefully handles empty json responses', async function () {
+    const scope = nock('https://localhost')
+      .post('/bloop', { bloop: true })
+      .reply(200);
+
+    const res = await request({
+      url: 'https://localhost/bloop',
+      json: true,
+      body: { bloop: true },
+      method: 'post',
+    });
+
+    assert.deepStrictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, undefined);
+
+    scope.done();
+  });
 });


### PR DESCRIPTION
This PR fixes a bug where if an HTTP response body was empty (`response.body === undefined`), we would improperly attempt to lookup an error key, as if a valid object was returned and parsed. 